### PR TITLE
Update databricks_source function to allow optional values

### DIFF
--- a/sources/databricks/__init__.py
+++ b/sources/databricks/__init__.py
@@ -11,8 +11,8 @@ from delta_sharing import SharingClient, load_as_pandas
 @dlt.source(name="databricks", max_table_nesting=2)
 def databricks_source(
     config_share_file: str,
-    date_column: str,
-    execution_date: None,
+    date_column: str|None = None,
+    execution_date: None = None,
     **kwargs
 ) -> Iterable[DltResource]:
     


### PR DESCRIPTION
This pull request includes changes to the `sources/databricks/__init__.py` file to improve the flexibility of the `databricks_source` function by making the `date_column` parameter optional.

* [`sources/databricks/__init__.py`](diffhunk://#diff-dbf5672edf287a19a1886a6ece8c7b97f7046144943db115e91eebeed746c475L14-R15): Modified the `databricks_source` function to allow the `date_column` parameter to be `None` by setting its default value to `None`.